### PR TITLE
Add DNS lookups to get the hostname of the source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,9 @@ RUN cd $CATALINA_HOME && \
     -s '/Server/Service/Engine/Host/Context[@path="/ROOT"]' -t 'attr' -n 'docBase' -v 'ROOT' \
     -s '/Server/Service/Engine/Host/Context[@path="/ROOT"]' -t 'elem' -n 'WatchedResource' -v 'WEB-INF/web.xml' \
     -s '/Server/Service/Engine/Host' -t 'elem' -n 'Valve' \
-    -s "/Server/Service/Engine/Host/Valve[not(@directory='logs')]" -t 'attr' -n 'className' -v 'org.apache.catalina.valves.RemoteHostValve' \
-    -s "/Server/Service/Engine/Host/Valve[not(@directory='logs')]" -t 'attr' -n 'allow' -v 'oostandarddev\-.*\.cern\.ch|oostandardprod\-.*\.cern\.ch' \
+    -s '/Server/Service/Engine/Host/Valve[not(@directory="logs")]' -t 'attr' -n 'className' -v 'org.apache.catalina.valves.RemoteHostValve' \
+    -s '/Server/Service/Engine/Host/Valve[not(@directory="logs")]' -t 'attr' -n 'allow' -v 'oostandarddev\-.*\.cern\.ch|oostandardprod\-.*\.cern\.ch' \
+    -s '/Server/Service/Connector[@port="8080"]' -t 'attr' -n 'enableLookups' -v 'true' \
     conf/server.xml
 
 WORKDIR $CATALINA_HOME


### PR DESCRIPTION
By default Tomcat does not get the domain names, it has to be activated and it consumes more resources.